### PR TITLE
Fix route loader not working on Windows

### DIFF
--- a/packages/core/src/utils/routes-loader.ts
+++ b/packages/core/src/utils/routes-loader.ts
@@ -35,7 +35,7 @@ export const extractPath = (file: string, dir: string) => {
 };
 
 export const loadRoutes = async (dir = apiDir()): Promise<ZephyrRoute[]> => {
-  const pattern = '**/{get,post,put,delete,patch,head}.ts';
+  const pattern = '**/{get,post,put,delete,patch}.ts';
   const files = glob
     .sync(pattern, {
       cwd: dir,

--- a/packages/core/src/utils/routes-loader.ts
+++ b/packages/core/src/utils/routes-loader.ts
@@ -35,9 +35,13 @@ export const extractPath = (file: string, dir: string) => {
 };
 
 export const loadRoutes = async (dir = apiDir()): Promise<ZephyrRoute[]> => {
-  const pattern = dir + '/**/{get,post,put,delete,patch,head}.ts';
-
-  const files = glob.sync(normalize(pattern));
+  const pattern = '**/{get,post,put,delete,patch,head}.ts';
+  const files = glob
+    .sync(pattern, {
+      cwd: dir,
+      absolute: true,
+    })
+    .map(normalize);
 
   return Promise.all(
     files.map(async (file) => {


### PR DESCRIPTION
The route loader glob pattern does not seem to work on Windows (tests are failing).
Using glob options makes it work.

Also removed `HEAD` from the glob pattern as it's not part of the ROUTE_METHODS array.