### PR TITLE
Add PATCH to methods

### DIFF
--- a/packages/common/src/interfaces/zephyr-request.ts
+++ b/packages/common/src/interfaces/zephyr-request.ts
@@ -1,6 +1,6 @@
 import type { Request as ExpressRequest } from 'express';
 
-export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 export interface ZephyrBaseRequest {
   params?: object;

--- a/packages/common/src/interfaces/zephyr-route.ts
+++ b/packages/common/src/interfaces/zephyr-route.ts
@@ -7,7 +7,7 @@ export interface ZephyrRoute<
   TRequest extends ZephyrBaseRequest = any,
   TResponse = any,
 > {
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   path: string;
   schema?: AnyZodObject;
   handler: ZephyrHandler<TRequest, TResponse>;
@@ -15,4 +15,4 @@ export interface ZephyrRoute<
   after?: RequestHandler | RequestHandler[];
 }
 
-export const ROUTE_METHODS = ['GET', 'POST', 'PUT', 'DELETE'] as const;
+export const ROUTE_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;


### PR DESCRIPTION
`PATCH` is part of the route loader glob pattern, but not the `ROUTE_METHODS` array.